### PR TITLE
"take" instead of "take $_"

### DIFF
--- a/lib/Syntax/Keyword/Gather.pm
+++ b/lib/Syntax/Keyword/Gather.pm
@@ -217,6 +217,18 @@ first line they have in common. We could gather the lines like this:
     }
  }
 
+If you like it really short, you can also gather-take $_ magically:
+
+my @numbers_with_two = gather {
+    for (1..20) {
+        take if /2/
+    }
+};
+# @numbers_with_two contains 2, 12, 20
+
+Be aware that $_ in Perl5 is a global variable rather than the
+current topic like in Perl6.
+
 =head1 HISTORY
 
 This module was forked from Damian Conway's L<Perl6::Gather> for a few reasons.

--- a/t/2_bare_take.t
+++ b/t/2_bare_take.t
@@ -1,0 +1,78 @@
+#!perl
+use strict;
+use warnings;
+
+use Test::More tests => 8;
+use Syntax::Keyword::Gather;
+
+# instructive example
+my @numbers_with_two = gather {
+    for (1..20) {
+        take if /2/
+    }
+};
+ok eq_array(
+    [@numbers_with_two],
+    [2,12,20],
+), 'bare take works';
+
+
+# tests copied from 1.t to show they all work without $_
+ok eq_array(
+   [gather { take for 1..10; take 99 }],
+   [1..10, 99],
+), 'basic gather works (bare take)' ;
+ok eq_array(
+   [gather { take for 1..10; take 99 unless gathered }],
+   [1..10],
+), 'gathered works with bare take in boolean context (true)';
+ok eq_array(
+   [gather { take for 1..10; pop @{+gathered} }],
+   [1..9]
+), 'gathered allows modification of underlying data with bare take';
+
+
+# some special tests
+ok eq_array(
+    [gather { take for (undef, undef)}],
+    [undef, undef]
+), 'undef gathers';
+
+# as a warning: never forget to take the loop variable or you are
+# taking $_ magically..
+$_ = 99;
+ok eq_array(
+    [
+        gather {
+            for my $i (1..2) {
+                take
+            }
+        }
+    ],
+    [99, 99]
+), 'takes 99 because hacker forgot to "take $i"';
+
+# and also inside loop..
+ok eq_array(
+    [
+        gather {
+            for my $i (1..2) {
+                $_ = $i *2;
+                take;
+            }
+        }
+    ],
+    [2,4]
+), 'taking manipulated $_ instead of (possibly intended $i)';
+
+
+# and, rather as a question:
+
+# not sure if this is wanted behaviour
+is(
+    gather { take undef },
+    '',
+    'take: undef becomes ""');
+
+
+


### PR DESCRIPTION
add feature for Perl 5 style "$_ less take", like so:

my @results =  gather {
    for (1..20){
        take if /2/; # instead of 'take $_'
    }
};

If this can be merged I will add some documentation, should that be desired.
