### PR TITLE
Fix invalid syntax in grep example

### DIFF
--- a/lib/Syntax/Keyword/Gather.pm
+++ b/lib/Syntax/Keyword/Gather.pm
@@ -190,7 +190,7 @@ as:
    my @list = @{shift @_};
 
    return gather {
-      take $_ if $coderef->($_) for @list
+      do { take $_ if $coderef->($_) } for @list
    };
  }
 


### PR DESCRIPTION
Other suggestions:

`$coderef->($_) and take $_ for @list`
`take $_ for grep { $coderef->($_) } @list` (probably confusing)