### PR TITLE
Eliminate uninitialized value warning

### DIFF
--- a/lib/Syntax/Keyword/Gather.pm
+++ b/lib/Syntax/Keyword/Gather.pm
@@ -54,7 +54,7 @@ package Syntax::Keyword::Gather::MagicArrayRef;
 use overload
    'bool'   => sub { @{$_[0]} > 0      },
    '0+'     => sub { @{$_[0]} + 0      },
-   '""'     => sub { join q{}, @{$_[0]} },
+   '""'     => sub { join q{}, map { defined($_) ? $_ : '' } @{$_[0]} },
    fallback => 1;
 
 1;


### PR DESCRIPTION
Observed when testing Syntax::Keyword::Gather as part of a larger module installation process.
```
Running make test for FREW/Syntax-Keyword-Gather-1.003002.tar.gz
PERL_DL_NONLAZY=1 "/usr/home/jkeenan/testing/blead/bin/perl" "-MExtUtils::Command::MM" "-MTest::Harness" "-e" "undef *Test::Harness::Switches; test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/1.t .................. ok
Use of uninitialized value in join or string at /usr/home/jkeenan/.cpan/build/Syntax-Keyword-Gather-1.003002-0/blib/lib/Syntax/Keyword/Gather.pm line 57.
t/2_bare_take.t ........ ok
t/author-pod-syntax.t .. skipped: these tests are for testing by the author
All tests successful.
Files=3, Tests=15,  0 wallclock secs ( 0.02 usr  0.01 sys +  0.16 cusr  0.02 csys =  0.22 CPU)
Result: PASS
```
Tested on blead perl.